### PR TITLE
docs: document setup Pis in office

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # nist-brski
+
 BRSKI demo for NIST
+
+## Devices
+
+On the office network, I have set up the following devices:
+
+- `nqm-britannic-brski.local`
+  - **Server**, has 2x USB WiFi AP
+  - Admins: `alois`, `alexandru`
+- `nqm-benign-brski.local`
+  - Admins: `alois`, `alexandru`
+- `nqm-biddable-brski.local`
+  - Admins: `alois`, `alexandru`


### PR DESCRIPTION
Document the pis that are setup in the office.

@mereacre, I've made an account for you called `alexandru` that has a disabled password and sudo access on all of these accounts.

I've added permission for the following SSH keys to login to `alexandru`:

```console
alexandru@nqm-biddable-brski:/home/alois$ cat ~/.ssh/authorized_keys
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBXeCdBDk0UnUd7dkjnmY6f1HlOd5qN4FwMgjXTesTph mereacre@gmail.com
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC8l2nLMWo9ClvEgdz8MGLKGb4VgP3O0IgvqYGAmbNN+PAbDda/Kpa5WzRWlZmYkZwEdSniiGJmJswbI6VgUkkMFRvckndjNrm7cwbRmYwWMekBWHhFxWQxlIvNQ2U4GtfrXV3xF/HxJVnx/ZgCgWltnjDjravu1B3KSpvhN+mmUFZ9ikH/n5KpBg6qk2dmZJ3vIDWeP9pmvwoCFNlems9oXo+R2X6SX5a5289ujmVKykfMO57X9CApEZiWdn1b1l+6HnpelUX/I5XvGBkH9FIQVIabScOSEPTVmiShnj2SAB9Z2dVuYN18v9y/dv6IHyiXmfdHDpF08Hl9zL8jf8XEe+XFdOZDf+MJcHfS9w4JrTIHCdOrzDcsnZpuPKTve1eQrJ4+K4EX7LF9LgLpxNIdA4UkROPpy9cXgfyjM3SHrP3+8wsvf8rDWFXkEAFe8cCmYq0RyZCLd0IVgTzWtFBcv4h4IJug3cr28yByg6ns8uLkl91PHJsY/jkFSJERWcU= alex@alex-XPS-13-9350
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID2LQxKwVwilT8v4zdVcv9nhkmy6OkY8BpqHHSlHq8M7 mereacre@gmail.com
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEXhNkT1ALiWBvUVxTbPLd4S3bvfEwOWLFTmiP4lHOix mereacre@gmail.com
```

You should be able to login to these by jumping through the `dazzling-dream` or `polite-pcspecialist` computers, e.g. something like `ssh -J alexandru@polite-pcspecialist alexandru@nqm-biddable-brski.local`

### To do before merging

@mereacre, can you test whether you can ssh into all of the documented pis, and you have `sudo` access?