### PR TITLE
Document NIST BRSKI hardware demo setup

### DIFF
--- a/brski-server/README.md
+++ b/brski-server/README.md
@@ -90,8 +90,10 @@ mDNS does not work for some reason).
 
 ### Configuring USB-C connection
 
-In order to enable the USB-C connection for data, you must making the following
-change in your `/boot/firmware/config.txt` (`/boot/config.txt` on Raspbian):
+The Raspberry Pi Model 4B supports USB Gadget mode, which can be used to
+communicate from one Pi to another Pi without the usage of a router and switch.
+
+Some of this guide is adapted from the steps in https://lozworld.com/lozwords/raspberry-pi-4b-as-an-ubuntu-2110-usb-gadget-tethered-to-an-ipad-pro.
 
 #### Host
 
@@ -189,7 +191,7 @@ Then, make a `/etc/default/dnsmasq.usb0` file with the following contents
 ```
 DNSMASQ_EXCEPT="lo"
 DNSMASQ_INTERFACE='usb0'
-DNSMASQ_OPTS='--bind-interfaces --dhcp-range=192.168.48.2,192.168.48.7,4h'
+DNSMASQ_OPTS='--bind-interfaces --dhcp-option=3 --dhcp-range=192.168.48.2,192.168.48.6,255.255.255.248,1h'
 ```
 
 Finally, you can start `dnsmasq` using:


### PR DESCRIPTION
@mereacre, @nallott I've managed to get the one of the BRSKI NIST Raspberry Pi 4Bs running as a server and one as a client, but no matter what I try, the last Raspberry Pi 4B is being extremely stubborn. It seems to be dropping packets, so maybe the USB-C cable is bad quality, or there's some SD-card corruption (I did take the SD-cards from the super old Raspberry Pis in the office, and they're incredibly slow).

**Nevertheless, we should at least be able to remotely update two of the Pis, which should be enough for a working demo.**

Getting the BRSKI demo working will probably still be a whole load of work, since the current httplib that BRSKI uses is basically impossible to debug, and that's not even including of the other bits that we need to make a working demo.

---

Below is a checklist of all the parts you should need (all should be on @nallott's desk). The only thing you should need to buy is a UK to US power adapter.

### Parts

- 1x Powered USB-C hub
  - 1x Powered USB-C hub Power Supply + IEC C13 cable.
    - Todo, buy an IEC C13 US cable, or get a UK to US power adapter.
- 3x Raspberry Pi 4Bs:
  - `nqm-brittanic-brski` (server)
  - `nqm-benign-brski` (client)
  - `nqm-biddable-brski` (client)
- 1x Raspberry Pi Power supply unit
  - Maybe bring one with a US plug?
- 2x USB-C to USB-C cables (ideally capable of 5V 3A)
- 1x USB-C to USB-A cable (ideally USB-3.0 for higher speed, and capable of 5V 3A)
- 1x RJ45 Ethernet cable
- 2x USB-A WiFi AP adapters

### Connection diagram

```mermaid
flowchart TD
    subgraph "USB-C hub"
      upstreamUsbC["`**USB-C** upstream fa:fa-desktop`"]
      power["`DC in fa:fa-plug`"]
      downstreamUsbA["`**USB-A** downstream (unused)`"]
      downstreamUsbC1["`**USB-C** downstream`"]
      downstreamUsbC2["`**USB-C** downstream`"]
      downstreamUsbC3["`**USB-C** downstream (unused)`"]
      upstreamUsbC ~~~ downstreamUsbC1
      upstreamUsbC ~~~ downstreamUsbC2
      upstreamUsbC ~~~ downstreamUsbC3
    end
    hubPsu["Hub PSU fa:fa-plug"] <----> power
    subgraph "nqm-brittanic-brski"
      hostUsbC["`**USB-C** connection`"]
      hostrj465["`RJ45 (Ethernet) connection`"]
      hostUsb3A1["`**USB-A 3.0** connection`"]
      hostUsb3A2["`**USB-A 3.0** connection (unused)`"]
      hostUsb2A1["`**USB-A 2.0** connection`"]
      hostUsb2A2["`**USB-A 2.0** connection`"]
    end
    hostUsb3A1 <--"`USB-C to USB-A cable`"--> upstreamUsbC
    hostUsb2A1 --> usbWifiAp1["`USB Wifi AP`"]
    hostUsb2A2 --> usbWifiAp2["`USB Wifi AP`"]
    subgraph "nqm-benign-brski"
        benignUsbC["`**USB-C** connection`"]
    end
    subgraph "nqm-biddable-brski"
        biddableUsbC["`**USB-C** connection`"]
    end
    downstreamUsbC1  <--"`USB-C to USB-C cable`"--> benignUsbC
    downstreamUsbC2  <--"`USB-C to USB-C cable`"--> biddableUsbC
    rasperryPiPsu["`Raspberry Pi 4 PSU fa:fa-plug`"] <--"USB-C power cable"--> hostUsbC
    nistUpstreamPort["`NIST upstream Ethernet port`"] <-- "Ethernet" --> hostrj465
```