### PR TITLE
add config for revoking certificates

### DIFF
--- a/brski-server/installer/payload/ca.conf
+++ b/brski-server/installer/payload/ca.conf
@@ -1,0 +1,21 @@
+[ ca ]
+default_ca = CA_default
+
+[ CA_default ]
+database = /etc/hostapd/CA/index.txt
+certificate = /etc/brski/registrar-tls-ca.crt
+private_key = /etc/brski/registrar-tls-ca.key
+crlnumber = /etc/hostapd/CA/crlnumber
+serial = /etc/hostapd/CA/serial
+default_md = sha256
+default_crl_days = 30
+default_days = 365
+policy = policy_match
+
+[ policy_match ]
+countryName = supplied
+stateOrProvinceName = optional
+organizationName = optional
+organizationalUnitName = optional
+commonName = supplied
+emailAddress = optional

--- a/brski-server/installer/payload/installer
+++ b/brski-server/installer/payload/installer
@@ -3,6 +3,10 @@
 IF0="wlan0"
 IF1="wlan1"
 
+CA_DIR="/etc/hostapd/CA"
+CA_CONF="$CA_DIR/ca.conf"
+COMBINED_CA_CRL="$CA_DIR/registrar-tls-ca-and-crl.crt"
+
 ip a show dev $IF0
 
 if [ $? -ne 0 ]; then
@@ -18,9 +22,9 @@ if [ $? -ne 0 ]; then
 fi
 
 # Configure BRSK tool
-wget -O /tmp/brski_0.2.3_arm64.deb https://github.com/nqminds/brski/releases/download/0.2.3/brski_0.2.3_arm64.deb
-dpkg -i /tmp/brski_0.2.3_arm64.deb
-rm /tmp/brski_0.2.3_arm64.deb
+wget -O /tmp/brski_0.2.6_arm64.deb https://github.com/nqminds/brski/releases/download/0.2.6/brski_0.2.6_arm64.deb
+dpkg -i /tmp/brski_0.2.6_arm64.deb
+rm /tmp/brski_0.2.6_arm64.deb
 
 cp certs/* /etc/brski
 
@@ -70,6 +74,24 @@ sed -i s/@wlan@/$IF0/g /etc/default/dnsmasq.$IF0
 
 cp dnsmasq-secure.conf /etc/default/dnsmasq.$IF1
 sed -i s/@wlan@/$IF1/g /etc/default/dnsmasq.$IF1
+
+sudo mkdir -p "$CA_DIR/"
+if [ $? -ne 0 ]; then
+    echo "Failed to create directory: $CA_DIR/"
+    exit 1
+fi
+
+cp ca.conf "$CA_DIR/"
+touch "$CA_DIR/index.txt"
+echo '1000' > "$CA_DIR/serial"
+touch "$CA_DIR/crlnumber"
+echo '01' > "$CA_DIR/crlnumber"
+
+openssl ca -gencrl -out "$CA_DIR/crl.crt" -config "$CA_CONF"
+sudo sh -c "cat $CA_CERT $CA_DIR/crl.crt > $COMBINED_CA_CRL"
+
+cp local_revoke_serial_multiple_args.sh "$CA_DIR/"
+cp local_revoke.sh "$CA_DIR/"
 
 sudo systemctl disable dnsmasq@$IF0.service
 sudo systemctl disable dnsmasq@$IF1.service

--- a/brski-server/installer/payload/local_revoke.sh
+++ b/brski-server/installer/payload/local_revoke.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# local_revoke.sh
+
+# Check if a certificate file path is provided
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 /path/to/client_cert.pem"
+    exit 1
+fi
+
+CLIENT_CERT="$1"
+CA_CONFIG="/etc/hostapd/CA/ca.conf"
+CA_CERT="/etc/brski/registrar-tls-ca.crt"
+CRL="/etc/hostapd/CA/crl.crt"
+COMBINED_CA_CRL="/etc/hostapd/CA/registrar-tls-ca-and-crl.crt"
+
+# Revoke the client certificate
+sudo openssl ca -revoke "$CLIENT_CERT" -config "$CA_CONFIG"
+
+# Update the CRL
+sudo openssl ca -gencrl -out "$CRL" -config "$CA_CONFIG"
+
+# Concatenate CA certificate and CRL
+sudo sh -c "cat $CA_CERT $CRL > $COMBINED_CA_CRL"
+
+# Verify if the certificate has been revoked
+if sudo openssl verify -extended_crl -verbose -CAfile "$COMBINED_CA_CRL" -crl_check "$CLIENT_CERT"; then
+    echo "Certificate revocation verification failed. Not restarting hostapd."
+else
+    echo "Certificate has been revoked. Restarting hostapd..."
+    # Restart hostapd
+    sudo systemctl restart hostapd@wlan1.service
+fi

--- a/brski-server/installer/payload/local_revoke_serial_multiple_args.sh
+++ b/brski-server/installer/payload/local_revoke_serial_multiple_args.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# local_revoke_serial_multiple_args.sh
+
+# Check if at least two serial numbers are provided and the number of arguments is even
+if [ "$#" -lt 2 ] || [ $(( $# % 2 )) -ne 0 ]; then
+    echo "Usage: $0 unique_serial_number1 serialNumber1 [unique_serial_number2 serialNumber2 ...]"
+    exit 1
+fi
+
+CA_DIR="/etc/hostapd/CA"
+CA_CONFIG="$CA_DIR/ca.conf"
+CRL="$CA_DIR/crl.crt"
+CA_CERT="/etc/brski/registrar-tls-ca.crt"
+COMBINED_CA_CRL="$CA_DIR/registrar-tls-ca-and-crl.crt"
+INDEX_FILE="$CA_DIR/index.txt"
+REVOCATION_DATE=$(date +"%y%m%d%H%M%SZ")
+update_crl=false
+
+while [ "$#" -gt 0 ]; do
+    UNIQUE_SERIAL="$1"
+    SERIAL_NUMBER="$2"
+    shift 2
+
+    # Convert and pad the UNIQUE_SERIAL number to the correct format
+    UNIQUE_SERIAL=$(echo "$UNIQUE_SERIAL" | sed 's/^0x//' | tr '[:lower:]' '[:upper:]' | sed 's/^0*//')
+
+    UNIQUE_SERIAL=$(printf '%016s' "$UNIQUE_SERIAL" | tr ' ' '0')
+
+    SERIAL_NUMBER=$(echo "$SERIAL_NUMBER" | tr '[:lower:]' '[:upper:]')
+
+    # Check if the serial number already exists in index.txt
+    if grep -q "$UNIQUE_SERIAL" "$INDEX_FILE"; then
+        echo "Serial Number $UNIQUE_SERIAL already exists in index.txt. Skipping addition."
+    else
+        # Add entry to the index.txt file
+        echo "Adding revocation entry to index.txt for certificate with serials $UNIQUE_SERIAL and $SERIAL_NUMBER..."
+        printf "R\t99991231235959Z\t%s\t%s\tunknown\t/C=IE/CN=ldevid-cert/serialNumber=%s\n" "$REVOCATION_DATE" "$UNIQUE_SERIAL" "$SERIAL_NUMBER" | sudo tee -a "$INDEX_FILE"
+            # Update the CRL
+        echo "Updating CRL..."
+        sudo openssl ca -gencrl -out "$CRL" -config "$CA_CONFIG"
+
+        # Concatenate CA certificate and CRL
+        echo "Updating combined CA and CRL file..."
+        sudo sh -c "cat $CA_CERT $CRL > $COMBINED_CA_CRL"
+
+        update_crl=true
+    fi
+done
+
+if [ "$update_crl" = true ]; then
+
+    echo "Certificates have been revoked. Restarting hostapd..."
+    # Restart hostapd
+    sudo systemctl restart hostapd@wlan1.service
+fi

--- a/brski-server/installer/payload/wlan-secure.conf
+++ b/brski-server/installer/payload/wlan-secure.conf
@@ -33,10 +33,21 @@ auth_server_shared_secret=1234554321
 # Use integrated EAP server instead of external RADIUS authentication server
 eap_server=1
 
+# Enable CRL verification.
+# Note: hostapd does not yet support CRL downloading based on CDP. Thus, a
+# valid CRL signed by the CA is required to be included in the ca_cert file.
+# This can be done by using PEM format for CA certificate and CRL and
+# concatenating these into one file. Whenever CRL changes, hostapd needs to be
+# restarted to take the new CRL into use.
+# 0 = do not verify CRLs (default)
+# 1 = check the CRL of the user certificate
+# 2 = check all CRLs in the certificate path
+check_crl=2
+
 # Path for EAP server user database
 eap_user_file=/etc/hostapd/eap_user
 
-ca_cert=/etc/brski/registrar-tls-ca.crt
+ca_cert=/etc/hostapd/CA/registrar-tls-ca-and-crl.crt
 server_cert=/etc/brski/registrar-tls.crt
 private_key=/etc/brski/registrar-tls.key
 


### PR DESCRIPTION
I've added the current configuration for revoking a ldevid.

@jr7g19 has created a service that invokes the local_revoke_serial_multiple_args.sh script when a device becomes untrusted. The script revokes ldevids based on their serial number.
 
Ideally, we'd want to revoke the entire certificate (local_revoke.sh). However, this is not possible because the registrar cannot obtain the ldevid.

I changed the brski-server to reflect this setting and published this draft PR.