### PR TITLE
trigger the debian builds only for brski app and server

### DIFF
--- a/.github/workflows/create-demo-app-debs.yml
+++ b/.github/workflows/create-demo-app-debs.yml
@@ -8,8 +8,14 @@ on:
     tags:
       - 'v0.0.1'
     branches: [ main ]
+    paths:
+      - 'debian-brski/**'
+      - 'brski-server/**'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'debian-brski/**'
+      - 'brski-server/**'
 
 jobs:
   


### PR DESCRIPTION
Changed the git actions to trigger only when the brski-server of debian-brski directories are modified.